### PR TITLE
chore(renovate): adopt central config from releasetools/.github

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "local>releasetools/.github"
   ]
 }


### PR DESCRIPTION
## Summary
- Adopts the org-wide Renovate preset at `releasetools/.github` via `extends: ["local>releasetools/.github"]`.
- Replaces any prior standalone `config:recommended` config so policy is centrally managed.

## Test plan
- [x] `renovate-config-validator` passes locally.
- [ ] After merge, the next Renovate run picks up the central policy (3-day `minimumReleaseAge`, weekly grouped GitHub Actions PR, SHA-pinned actions).