### PR TITLE
Reference MihaiBojin/renovate directly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-15, macos-26]
+        os: [ubuntu-24.04, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>releasetools/.github"
+    "github>MihaiBojin/renovate",
+    "github>MihaiBojin/renovate:group-github-actions",
+    "github>MihaiBojin/renovate:lock-file-maintenance",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
Drops the `releasetools/.github` indirection and extends the shared preset directly, matching what `releasetools/mutex` already does.

## Why

`releasetools/.github/default.json` mostly **restated** the shared baseline — same 3-day release age, same `internalChecksFilter`, same vulnerability and OSV handling, same non-npm exception rules. A layer that copies what it wraps is a layer that can drift from it, which is how the deprecated `npm:unpublishSafe` name ended up surviving in three separate preset repos.

## What it looks like now

```json
{
  "extends": [
    "github>MihaiBojin/renovate",
    "github>MihaiBojin/renovate:group-github-actions",
    "github>MihaiBojin/renovate:lock-file-maintenance",
    "helpers:pinGitHubActionDigests"
  ]
}
```

Everything the old preset contributed beyond the baseline is now opted into **by name** rather than inherited invisibly: weekly lock file maintenance, the Actions roll-up, and pinned action digests. `lock-file-maintenance` is a new profile added for exactly this, so nothing is silently lost in the move.

## One deliberate behaviour change

The old rule grouped **every** GitHub Actions update on a weekly schedule. `group-github-actions` covers **non-major only**.

So action majors now arrive as their own PR instead of being rolled into the weekly batch. That is the outcome worth having — a major action bump is where a human is actually wanted, and it is the same split `mutex` has been running with.

## Sequencing

Safe to merge independently. `releasetools/.github` still exists and still resolves; it is only removed once every repo has moved off it.