### PR TITLE
ci: add ubuntu-26.04 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15, macos-26]
+        os: [ubuntu-24.04, ubuntu-26.04, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
Adds the `ubuntu-26.04` hosted runner alongside `ubuntu-24.04` so bottles are built and tested on both Ubuntu LTS releases.

`ubuntu-26.04` is still flagged as preview by GitHub, so `ubuntu-24.04` stays in the matrix rather than being replaced.

Matrix is now: `ubuntu-24.04`, `ubuntu-26.04`, `macos-15`, `macos-26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)