### PR TITLE
chore(formula): update releasetools-cli to v0.0.13

### DIFF
--- a/Formula/releasetools-cli.rb
+++ b/Formula/releasetools-cli.rb
@@ -1,8 +1,8 @@
 class ReleasetoolsCli < Formula
   desc "Release tools for GitHub workflows and local use"
   homepage "https://release.tools"
-  url "https://github.com/releasetools/cli/releases/download/v0.0.12/releasetools.bash"
-  sha256 "331773a21828008b350cb6414605322f89873ead7aec35df5f5229e25e67605a"
+  url "https://github.com/releasetools/cli/releases/download/v0.0.13/releasetools.bash"
+  sha256 "a71bb5e42e2d81ed07a3cd23d4a40fb731243d7bd188ac30e47e3ad7260e79eb"
   license "Apache-2.0"
   head "https://github.com/releasetools/cli.git", branch: "main"
 


### PR DESCRIPTION
Points the formula at the `releasetools.bash` asset from [v0.0.13](https://github.com/releasetools/cli/releases/tag/v0.0.13), with the `sha256` taken from the checksum published alongside it after verifying the download against it.

Generated by `scripts/bump-formula.sh` via the Bump formula workflow. Opened by hand because the workflow's `gh pr create` step failed:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests
```

The bump itself worked and the branch was pushed correctly. Only PR creation was blocked, by `can_approve_pull_request_reviews=false` on this repo. See releasetools/cli#30 for the fix.

Checksum confirmed against the live asset:

```
published asset: a71bb5e42e2d81ed07a3cd23d4a40fb731243d7bd188ac30e47e3ad7260e79eb
in this branch:  a71bb5e42e2d81ed07a3cd23d4a40fb731243d7bd188ac30e47e3ad7260e79eb
```