### PR TITLE
Make a blocked pull request actionable, and recover on rerun

### DIFF
--- a/.github/workflows/bump-formula.yml
+++ b/.github/workflows/bump-formula.yml
@@ -65,16 +65,23 @@ jobs:
             exit 1
           fi
 
+          # The branch can already exist from an earlier run whose push succeeded but whose
+          # pull request did not. Only skip when there is also a pull request open for it,
+          # otherwise the rerun would report success while leaving the branch unmerged.
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            echo "Branch $branch already exists; nothing to do." >&2
-            exit 0
+            if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+              echo "Branch $branch is already pushed and has an open pull request." >&2
+              exit 0
+            fi
+            echo "Branch $branch exists with no open pull request; opening one." >&2
+            git checkout -B "$branch" "origin/$branch"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git checkout -b "$branch"
+            git commit -m "chore(formula): update releasetools-cli to $VERSION"
+            git push origin "$branch"
           fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          git commit -m "chore(formula): update releasetools-cli to $VERSION"
-          git push origin "$branch"
 
           # Built with printf so the YAML block indentation does not end up in the body.
           body="$(printf '%s\n\n%s\n' \
@@ -82,7 +89,26 @@ jobs:
             "Opened by \`.github/workflows/bump-formula.yml\`.")"
 
           # --base is omitted so gh targets the repository's default branch.
-          gh pr create \
+          if out="$(gh pr create \
             --head "$branch" \
             --title "chore(formula): update releasetools-cli to $VERSION" \
-            --body "$body"
+            --body "$body" 2>&1)"; then
+            echo "$out"
+            exit 0
+          fi
+
+          echo "$out" >&2
+          compare="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${branch}?expand=1"
+
+          # The branch is pushed and the formula in it is correct, so the bump is not lost.
+          # Still a failure: the job's purpose is to leave a reviewable pull request, and a
+          # green tick here would mean nobody finds out it stopped halfway.
+          case "$out" in
+          *"not permitted to create or approve pull requests"*)
+            echo "::error::Pushed $branch but could not open a pull request. Either enable Settings > Actions > General > Allow GitHub Actions to create and approve pull requests, or land releasetools/cli#30 so this step runs as the automation GitHub App. Open it by hand meanwhile: $compare"
+            ;;
+          *)
+            echo "::error::Pushed $branch but could not open a pull request, see the output above. Open it by hand: $compare"
+            ;;
+          esac
+          exit 1


### PR DESCRIPTION
The v0.0.13 bump failed at the last step ([run](https://github.com/releasetools/homebrew-tap/actions/runs/30579224301)):

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests
```

`can_approve_pull_request_reviews=false` on this repo, which is GitHub's default. I flagged this as a caveat on #16; now it's real.

**The bump itself was fine.** `bump-formula-v0.0.13` was pushed with the right url, and its sha256 matches the published asset exactly:

```
published asset: a71bb5e42e2d81ed07a3cd23d4a40fb731243d7bd188ac30e47e3ad7260e79eb
in the branch:   a71bb5e42e2d81ed07a3cd23d4a40fb731243d7bd188ac30e47e3ad7260e79eb
```

Opened by hand as #17.

## What this changes

**The error is now actionable.** It said nothing about the work having survived or what to do next. It now names the pushed branch, links the compare page, and gives both fixes: enable the repo setting, or land releasetools/cli#30 so the step runs as the automation GitHub App.

I'd take the App. Enabling the setting also lets workflows *approve* pull requests, which is why it's off by default, and it wouldn't fix the related problem that a `GITHUB_TOKEN`-opened PR has its `brew test-bot` gated pending approval.

**It still fails.** The branch is pushed and correct, so nothing is lost, but the job's purpose is to leave a reviewable PR. A green tick would mean nobody finds out it stopped halfway.

**The rerun path was the real bug.** `branch already exists` returned 0 and skipped everything, so re-running after this precise failure would have reported success while leaving the branch with no PR, permanently. That's the silent-success shape this whole tap workflow exists to avoid, sitting in the recovery path. It now skips only when a PR is genuinely open for the branch, and otherwise checks it out and retries.

Confirmed against the live state: with #17 open, the new logic exits 0 correctly.

`actionlint` clean, `brew style` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)