### PR TITLE
Drop the python3 dependency, and stop a failing test reporting success

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,11 @@ jobs:
       - name: Install the formula and run its test block
         if: github.event_name == 'pull_request'
         run: |
-          brew install --formula --verbose ./Formula/releasetools-cli.rb
-          brew test --verbose releasetools-cli
+          # Tap-qualified, not a path: brew rejects a bare formula file with
+          # "Homebrew requires formulae to be in a tap". setup-homebrew has already
+          # tapped this checkout as releasetools/tap, so this tests the PR's formula.
+          brew install --formula --verbose releasetools/tap/releasetools-cli
+          brew test --verbose releasetools/tap/releasetools-cli
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,9 @@ jobs:
 
       # test-bot downgraded a failing formula test to SKIPPED and still exited 0, so the
       # v0.0.13 bump reported success while `releasetools base::check_deps` was erroring
-      # with "python is not installed". brew test exits non-zero when the test block
-      # fails, which is what this gate actually needs.
+      # with "python is not installed" (the formula depended on python3 for a single
+      # function that releasetools/cli#35 later removed entirely). brew test exits
+      # non-zero when the test block fails, which is what this gate actually needs.
       - name: Install the formula and run its test block
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,10 @@ jobs:
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'
 
-      # test-bot downgraded a failing formula test to SKIPPED and still exited 0, so the
-      # v0.0.13 bump reported success while `releasetools base::check_deps` was erroring
-      # with "python is not installed" (the formula depended on python3 for a single
-      # function that releasetools/cli#35 later removed entirely). brew test exits
-      # non-zero when the test block fails, which is what this gate actually needs.
+      # test-bot's own step above can silently pass over a real failure: it downgrades
+      # a failing `brew test` to SKIPPED and still exits 0. That is how a formula whose
+      # test block genuinely errored once merged with a green check (see #19). brew
+      # test exits non-zero when the test block fails, which is what this gate needs.
       - name: Install the formula and run its test block
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,14 @@ jobs:
           # Tap-qualified, not a path: brew rejects a bare formula file with
           # "Homebrew requires formulae to be in a tap". setup-homebrew has already
           # tapped this checkout as releasetools/tap, so this tests the PR's formula.
-          brew install --formula --verbose releasetools/tap/releasetools-cli
+          #
+          # Dependencies are installed explicitly because test-bot leaves the formula
+          # installed while uninstalling what it depends on, so brew install is a no-op
+          # here and brew test then refuses with "missing test dependencies:
+          # ... python@3.14". The formula install stays as a no-op safety net for the
+          # case where test-bot did not install it at all.
+          brew install --formula --only-dependencies releasetools/tap/releasetools-cli
+          brew install --formula releasetools/tap/releasetools-cli
           brew test --verbose releasetools/tap/releasetools-cli
 
       - name: Upload bottles as artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,16 @@ jobs:
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'
 
+      # test-bot downgraded a failing formula test to SKIPPED and still exited 0, so the
+      # v0.0.13 bump reported success while `releasetools base::check_deps` was erroring
+      # with "python is not installed". brew test exits non-zero when the test block
+      # fails, which is what this gate actually needs.
+      - name: Install the formula and run its test block
+        if: github.event_name == 'pull_request'
+        run: |
+          brew install --formula --verbose ./Formula/releasetools-cli.rb
+          brew test --verbose releasetools-cli
+
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,9 @@ jobs:
           #
           # Dependencies are installed explicitly because test-bot leaves the formula
           # installed while uninstalling what it depends on, so brew install is a no-op
-          # here and brew test then refuses with "missing test dependencies:
-          # ... python@3.14". The formula install stays as a no-op safety net for the
-          # case where test-bot did not install it at all.
+          # here and brew test then refuses with "missing test dependencies". The formula
+          # currently declares none, which makes that line a no-op too -- it is kept so
+          # the gate does not quietly break again if one is ever added back.
           brew install --formula --only-dependencies releasetools/tap/releasetools-cli
           brew install --formula releasetools/tap/releasetools-cli
           brew test --verbose releasetools/tap/releasetools-cli

--- a/Formula/releasetools-cli.rb
+++ b/Formula/releasetools-cli.rb
@@ -1,20 +1,17 @@
 class ReleasetoolsCli < Formula
   desc "Release tools for GitHub workflows and local use"
   homepage "https://release.tools"
-  url "https://github.com/releasetools/cli/releases/download/v0.0.15/releasetools.bash"
-  sha256 "134b2eb3b1251cc466adfd81e51905844834bedb783b333690cdeda4b58b1af4"
+  url "https://github.com/releasetools/cli/releases/download/v0.0.16/releasetools.bash"
+  sha256 "cfacbd8f19f25f808f08dd559fae35401c322d32ae7ba9b93ca4447ba1f37dc4"
   license "Apache-2.0"
   head "https://github.com/releasetools/cli.git", branch: "main"
 
-  # Runtime, not :build. The python:: module shells out to python3 every time it runs, so
-  # a build-time dependency left `releasetools base::check_deps` failing with "python is
-  # not installed" on any machine without one. Nothing else in the library needs python.
-  depends_on "python3"
+  # No dependencies. Every module is bash over git, gh and coreutils since
+  # releasetools/cli#35 removed the python:: namespace, so there is nothing to declare.
+  # Depending on python3 would have pulled 9 formulae and 126MB for a single function
+  # that no repository called.
 
   def install
-    # No pip install: the library reads pyproject.toml with tomllib, which is in the
-    # standard library from python 3.11. It used to install the third-party "toml" here,
-    # into a prefix the interpreter resolved at runtime never saw.
     bin.install "releasetools.bash" => "releasetools"
     bin.install_symlink bin/"releasetools" => "rt"
   end

--- a/Formula/releasetools-cli.rb
+++ b/Formula/releasetools-cli.rb
@@ -1,8 +1,8 @@
 class ReleasetoolsCli < Formula
   desc "Release tools for GitHub workflows and local use"
   homepage "https://release.tools"
-  url "https://github.com/releasetools/cli/releases/download/v0.0.13/releasetools.bash"
-  sha256 "a71bb5e42e2d81ed07a3cd23d4a40fb731243d7bd188ac30e47e3ad7260e79eb"
+  url "https://github.com/releasetools/cli/releases/download/v0.0.14/releasetools.bash"
+  sha256 "edee9180fe0bd4f38d173b860912c2f44c657db5c178155b370f81531c317afe"
   license "Apache-2.0"
   head "https://github.com/releasetools/cli.git", branch: "main"
 

--- a/Formula/releasetools-cli.rb
+++ b/Formula/releasetools-cli.rb
@@ -1,8 +1,8 @@
 class ReleasetoolsCli < Formula
   desc "Release tools for GitHub workflows and local use"
   homepage "https://release.tools"
-  url "https://github.com/releasetools/cli/releases/download/v0.0.14/releasetools.bash"
-  sha256 "edee9180fe0bd4f38d173b860912c2f44c657db5c178155b370f81531c317afe"
+  url "https://github.com/releasetools/cli/releases/download/v0.0.15/releasetools.bash"
+  sha256 "134b2eb3b1251cc466adfd81e51905844834bedb783b333690cdeda4b58b1af4"
   license "Apache-2.0"
   head "https://github.com/releasetools/cli.git", branch: "main"
 

--- a/Formula/releasetools-cli.rb
+++ b/Formula/releasetools-cli.rb
@@ -6,11 +6,15 @@ class ReleasetoolsCli < Formula
   license "Apache-2.0"
   head "https://github.com/releasetools/cli.git", branch: "main"
 
-  depends_on "python3" => :build
+  # Runtime, not :build. The python:: module shells out to python3 every time it runs, so
+  # a build-time dependency left `releasetools base::check_deps` failing with "python is
+  # not installed" on any machine without one. Nothing else in the library needs python.
+  depends_on "python3"
 
   def install
-    # system Formula["python"].opt_bin/"pip3", "install", "--user", "--break-system-packages", "toml"
-    system "python3", "-m", "pip", "install", *std_pip_args(build_isolation: true), "toml"
+    # No pip install: the library reads pyproject.toml with tomllib, which is in the
+    # standard library from python 3.11. It used to install the third-party "toml" here,
+    # into a prefix the interpreter resolved at runtime never saw.
     bin.install "releasetools.bash" => "releasetools"
     bin.install_symlink bin/"releasetools" => "rt"
   end


### PR DESCRIPTION
Two things: the formula loses its only dependency, and the CI gate that couldn't fail is replaced with one that can.

## No dependencies at all

releasetools/cli#35 removed the `python::` namespace, so the library is bash over `git`, `gh` and coreutils and the formula has nothing left to declare. **That's 9 recursive formulae and 126 MB back**, for a single function no repository called.

The journey through this PR is worth recording, because each step was wrong for a different reason:

| | |
|---|---|
| Before | `depends_on "python3" => :build` — a *build* dependency for a *runtime* need, plus a `pip install toml` into a prefix the runtime interpreter never saw. `brew test` died with `python is not installed`. |
| Mid-PR | `depends_on "python3"` — correct, and 126 MB for one function. |
| Now | nothing. The function is gone. |

Verified against the published **v0.0.16** with no interpreter anywhere on `PATH`, running exactly what the test block runs:

```
python3 present?         NO
releasetools version     -> v0.0.16
releasetools check_deps  -> Ok.      rc=0
```

Checksum matches the published asset (`cfacbd8f…`).

## The gate that couldn't fail

`brew test-bot` logged this and still exited 0, with the check run reporting **success**:

```
BuildError: Failed executing: .../bin/releasetools base::check_deps
==> SKIPPED releasetools/tap/releasetools-cli
```

The one check protecting this formula was incapable of failing. An explicit step now runs after it, because `brew test` exits non-zero when the test block does.

It took three attempts, each a real lesson about Homebrew rather than a typo:

1. `./Formula/releasetools-cli.rb` → *"Homebrew requires formulae to be in a tap"*. Fixed by using the tap-qualified name, which `setup-homebrew` has already pointed at this checkout.
2. → *"missing test dependencies: … python@3.14"*. test-bot leaves the **formula** installed while uninstalling what it **depends on**, so `brew install` was a no-op. Fixed by installing dependencies explicitly.
3. Green.

That history is the argument for the gate: it demonstrably *can* fail, which is exactly what `test-bot`'s own step could not do.

`--only-dependencies` is now a no-op since the formula has no dependencies. Kept deliberately, so the gate doesn't quietly break again if one is added back — confirmed it exits 0 when there's nothing to install.

## Supersedes #17

#17 bumps to v0.0.13, three releases stale and its test block cannot pass. Worth closing.

`brew style` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)